### PR TITLE
Fix RMAP

### DIFF
--- a/de.uka.ipd.sdq.sensorframework.buckminster/sensorframework.rmap
+++ b/de.uka.ipd.sdq.sensorframework.buckminster/sensorframework.rmap
@@ -9,7 +9,30 @@
 	<rm:locator pattern="^de\.uka\.ipd\.sdq\.[dialogs|errorhandling|identifier|probfuction|statistics|stoex|units].*" searchPathRef="commons" failOnError="true" />
 	<rm:locator pattern="^org\.palladiosimulator\.commons.*" searchPathRef="commons" failOnError="true" />
 
-	<rm:redirect pattern=".*" href="https://anonymous:anonymous@svnserver.informatik.kit.edu/i43/svn/code/ThirdPartyWrapper/trunk/org.palladiosimulator.thirdpartywrapper.buckminster/thirdpartywrapper.rmap" />
+	<rm:locator pattern="^org\.palladiosimulator\.thirdpartywrapper.*" searchPathRef="thirdparty"/>
+	<rm:locator pattern="^ca\.umontreal\.iro\.lecuyer\.ssj.*" searchPathRef="thirdparty" failOnError="false"/>
+	<rm:locator pattern="^ch\.ethz\.iks\.r_osgi.*" searchPathRef="thirdparty" failOnError="false"/>
+	<rm:locator pattern="^de\.desmoj.*" searchPathRef="thirdparty" failOnError="false"/>
+	<rm:locator pattern="^de\.ikv\.medini\.qvt.*" searchPathRef="thirdparty" failOnError="false"/>
+	<rm:locator pattern="^org\.apache\.chemistry\.opencmis.*" searchPathRef="thirdparty" failOnError="false"/>
+	<rm:locator pattern="^org\.apache\.commons\.collections15.*" searchPathRef="thirdparty" failOnError="false"/>
+	<rm:locator pattern="^org\.apache\.commons\.logging\.fragment.*" searchPathRef="thirdparty" failOnError="false"/>
+	<rm:locator pattern="^org\.apache\.commons\.math3.*" searchPathRef="thirdparty" failOnError="false"/>
+	<rm:locator pattern="^org\.apache\.commons\.csv.*" searchPathRef="thirdparty" failOnError="false"/>
+	<rm:locator pattern="^org\.jfree\.jfreechart.*" searchPathRef="thirdparty" failOnError="false"/>
+	<rm:locator pattern="^org\.jscience.*" searchPathRef="thirdparty" failOnError="false"/>
+	<rm:locator pattern="^org\.opt4j.*" searchPathRef="thirdparty" failOnError="false"/>
+	<rm:locator pattern="^org\.rosuda.*" searchPathRef="thirdparty" failOnError="false"/>
+	<rm:redirect pattern=".*" href="https://raw.githubusercontent.com/PalladioSimulator/Palladio-Build-Infrastructure/master/org.palladiosimulator.targetPlatformBuild/license.rmap"/>
+
+	<rm:searchPath name="thirdparty">
+		<rm:provider componentTypes="osgi.bundle,eclipse.feature" resolutionFilter="(resolveFrom=nightly)" readerType="p2" source="false" mutable="false">
+			<rm:uri format="http://sdqweb.ipd.kit.edu/eclipse/thirdpartywrapper/nightly/"/>
+		</rm:provider>
+		<rm:provider componentTypes="osgi.bundle,eclipse.feature" resolutionFilter="(resolveFrom=release)" readerType="p2" source="false" mutable="false">
+			<rm:uri format="http://sdqweb.ipd.kit.edu/eclipse/thirdpartywrapper/releases/latest/" />
+		</rm:provider>
+	</rm:searchPath>
 
 	<rm:searchPath name="commons">
 		<rm:provider componentTypes="osgi.bundle,eclipse.feature" resolutionFilter="(resolveFrom=nightly)" readerType="p2" source="false" mutable="false">

--- a/de.uka.ipd.sdq.sensorframework.buckminster/sensorframework.rmap
+++ b/de.uka.ipd.sdq.sensorframework.buckminster/sensorframework.rmap
@@ -1,28 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <rm:rmap xmlns:bc="http://www.eclipse.org/buckminster/Common-1.0" xmlns:rm="http://www.eclipse.org/buckminster/RMap-1.0">
 
-  <rm:property key="resolveFrom" value="release"/>
+	<rm:property key="resolveFrom" value="release"/>
 
-  <rm:locator pattern="^de\.uka\.ipd\.sdq\.sensorframework.*" searchPathRef="sensorframework" failOnError="true"/>
-  <rm:locator pattern="^de\.uka\.ipd\.sdq\.codegen\.simudatavisualisation\.datatypes$" searchPathRef="sensorframework" failOnError="true"/>
+	<rm:locator pattern="^de\.uka\.ipd\.sdq\.sensorframework.*" searchPathRef="sensorframework" failOnError="true"/>
+	<rm:locator pattern="^de\.uka\.ipd\.sdq\.codegen\.simudatavisualisation\.datatypes$" searchPathRef="sensorframework" failOnError="true"/>
 
-  <rm:redirect pattern=".*" href="https://raw.githubusercontent.com/PalladioSimulator/Palladio-Core-Commons/master/org.palladiosimulator.commons.buckminster/commons.rmap"/>
+	<rm:locator pattern="^de\.uka\.ipd\.sdq\.[dialogs|errorhandling|identifier|probfuction|statistics|stoex|units].*" searchPathRef="commons" failOnError="true" />
+	<rm:locator pattern="^org\.palladiosimulator\.commons.*" searchPathRef="commons" failOnError="true" />
 
-  <rm:searchPath name="sensorframework">
-    <rm:provider  resolutionFilter="(resolveFrom=nightly)" componentTypes="osgi.bundle,eclipse.feature" readerType="p2" source="false" mutable="false">
-      <rm:uri format="http://sdqweb.ipd.kit.edu/eclipse/sensorframework/nightly"/>
-    </rm:provider>
-    <rm:provider  resolutionFilter="(resolveFrom=release)" componentTypes="osgi.bundle,eclipse.feature" readerType="p2" source="false" mutable="false">
-      <rm:uri format="http://sdqweb.ipd.kit.edu/eclipse/sensorframework/releases/latest"/>
-    </rm:provider>
-    <rm:provider componentTypes="eclipse.feature,osgi.bundle" readerType="git" source="true">
-      <rm:uri format="{0}/GIT,{1}">
-        <bc:propertyRef key="workspace.root" />
-        <bc:propertyRef key="buckminster.component" />
-      </rm:uri>
-      <rm:property key="git.remote.uri" value="https://github.com/PalladioSimulator/Palladio-QuAL-SensorFramework"/>
-      <rm:property key="git.auto.fetch" value="true"/>
-    </rm:provider>
-  </rm:searchPath>
+	<rm:redirect pattern=".*" href="https://anonymous:anonymous@svnserver.informatik.kit.edu/i43/svn/code/ThirdPartyWrapper/trunk/org.palladiosimulator.thirdpartywrapper.buckminster/thirdpartywrapper.rmap" />
+
+	<rm:searchPath name="commons">
+		<rm:provider componentTypes="osgi.bundle,eclipse.feature" resolutionFilter="(resolveFrom=nightly)" readerType="p2" source="false" mutable="false">
+			<rm:uri format="https://sdqweb.ipd.kit.edu/eclipse/commons/nightly/"/>
+		</rm:provider>
+		<rm:provider componentTypes="osgi.bundle,eclipse.feature" resolutionFilter="(resolveFrom=release)" readerType="p2" source="false" mutable="false">
+			<rm:uri format="https://sdqweb.ipd.kit.edu/eclipse/commons/releases/latest/"/>
+		</rm:provider>
+	</rm:searchPath>
+
+	<rm:searchPath name="sensorframework">
+		<rm:provider  resolutionFilter="(resolveFrom=nightly)" componentTypes="osgi.bundle,eclipse.feature" readerType="p2" source="false" mutable="false">
+			<rm:uri format="http://sdqweb.ipd.kit.edu/eclipse/sensorframework/nightly"/>
+		</rm:provider>
+		<rm:provider  resolutionFilter="(resolveFrom=release)" componentTypes="osgi.bundle,eclipse.feature" readerType="p2" source="false" mutable="false">
+			<rm:uri format="http://sdqweb.ipd.kit.edu/eclipse/sensorframework/releases/latest"/>
+		</rm:provider>
+		<rm:provider componentTypes="eclipse.feature,osgi.bundle" readerType="git" source="true">
+			<rm:uri format="{0}/GIT,{1}">
+				<bc:propertyRef key="workspace.root" />
+				<bc:propertyRef key="buckminster.component" />
+			</rm:uri>
+			<rm:property key="git.remote.uri" value="https://github.com/PalladioSimulator/Palladio-QuAL-SensorFramework"/>
+			<rm:property key="git.auto.fetch" value="true"/>
+		</rm:provider>
+	</rm:searchPath>
 
 </rm:rmap>


### PR DESCRIPTION
Because of the migration of PCM Commons and ThirdPartyWrapper, the rmap is not working anymore. The commits include the content of both rmaps into this rmap to fix build issues.